### PR TITLE
Support import lombok.*

### DIFF
--- a/delombok.sh
+++ b/delombok.sh
@@ -16,4 +16,7 @@ fi
 
 find "$dir" -name "*.java" -type f | while read jf; do
   python3 "${here}/delombok.py" "$jf" "$jf"
+  # Replace imports of lombok.* with lombok.NonNull, otherwise the delomboked
+  # file will still be ignored by CodeQL
+  sed -r -i "s/^import[[:space:]]+lombok\.\*;$/import lombok.NonNull;/g" "$jf"
 done


### PR DESCRIPTION
The delomboking process normally removes lombok related imports. However, `import lombok.*;` is retained, because because there is one lombok feature - `lombok.NonNull` - which does not require "delomboking" and can be left in the code, and the delomboking process isn't smart enough to figure out if `import lombok.*` is required for use of `NonNull` in the code.

CodeQL typically ignores any file with a lombok import, with the notable exception of `lombok.NonNull`, which is permitted. This PR replaces all `lombok.*` imports with `lombok.NonNull` after delomboking to stop CodeQL ignoring those files.