### PR TITLE
Remove @Generated annotations

### DIFF
--- a/delombok.sh
+++ b/delombok.sh
@@ -19,4 +19,9 @@ find "$dir" -name "*.java" -type f | while read jf; do
   # Replace imports of lombok.* with lombok.NonNull, otherwise the delomboked
   # file will still be ignored by CodeQL
   sed -r -i "s/^import[[:space:]]+lombok\.\*;$/import lombok.NonNull;/g" "$jf"
+  # Remove any @Generated annotations, as they would prevent CodeQL from analyzing
+  # the file. This can happen if, for example, already delomboked code is stored
+  # in the repository.
+  sed -r -i "s/import[[:space:]]+lombok\.Generated;//g" "$jf"
+  sed -r -i "s/@Generated( |$)//g" "$jf"
 done


### PR DESCRIPTION
Any pre-existing `@Generated` annotations are not removed by delomboking and can prevent CodeQL from analyzing the file, so should be removed.