### PR TITLE
Remove all lombok imports except `lombok.NonNull`

### DIFF
--- a/delombok.sh
+++ b/delombok.sh
@@ -18,10 +18,11 @@ find "$dir" -name "*.java" -type f | while read jf; do
   python3 "${here}/delombok.py" "$jf" "$jf"
   # Replace imports of lombok.* with lombok.NonNull, otherwise the delomboked
   # file will still be ignored by CodeQL
-  sed -r -i "s/^import[[:space:]]+lombok\.\*;$/import lombok.NonNull;/g" "$jf"
+  sed -r -i 's/^import[[:space:]]+lombok\.\*;$/import lombok.NonNull;/g' "$jf"
+  # Remove any remaining lombok imports (except NonNull)
+  sed -r -i '/^.*NonNull;/! s/import[[:space:]]+lombok\..*;//g' "$jf"
   # Remove any @Generated annotations, as they would prevent CodeQL from analyzing
   # the file. This can happen if, for example, already delomboked code is stored
   # in the repository.
-  sed -r -i "s/import[[:space:]]+lombok\.Generated;//g" "$jf"
-  sed -r -i "s/@Generated( |$)//g" "$jf"
+  sed -r -i 's/@Generated( |$)//g' "$jf"
 done


### PR DESCRIPTION
Lombok imports (other than NonNull) cause CodeQL to ignore the file, and after delomboking has happened should be redundant. This can happen, for example, if there are unused imports in the file.